### PR TITLE
Fix error in old node versions

### DIFF
--- a/scripts/androidBeforeInstall.js
+++ b/scripts/androidBeforeInstall.js
@@ -16,6 +16,7 @@ module.exports = function(ctx) {
             fs.createReadStream(settingsFile).pipe(fs.createWriteStream('platforms/android/google-services.json'));
 
             var lineReader = readline.createInterface({
+                terminal: false,
                 input : fs.createReadStream('platforms/android/build.gradle')
             });
             lineReader.on("line", function(line) {


### PR DESCRIPTION
Plugin fails to install in node 0.10.x if you don't pass the terminal false param